### PR TITLE
Removing skip check to work with forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ Creates a serverless endpoint for a GitHub App to check if NPM versions get bump
 
 Uses [GitHub Checks API](https://developer.github.com/v3/checks/) to show if the NPM version from pull request branch is greater than the version of the base branch.
 
-#### Skip checks
-
-Use `skip-checks: true`, as described [here](https://help.github.com/articles/about-status-checks/#skipping-and-requesting-checks-for-individual-commits)
-
 #### Evaluation modes
 
 Place the text `#version-checkr: <flag>` at the start of any line in the pull request description to set any of the flags below.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "versioncheckr",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -253,9 +253,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.344.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.344.0.tgz",
-      "integrity": "sha512-VGiVgX4+qk/67o8GL3qeHK1KC4r73jlsJoE6ZSPsujX6UjP0PgrfUL1J9cdW/sgXc0lzmK3ksdKqZordFZ4/xw==",
+      "version": "2.346.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.346.0.tgz",
+      "integrity": "sha512-4nJfbsK5Chu1ujIHHuvzRz7Ypu9Rbb8KQ/9T5QkVKUaQkl7AUnaUyENykIjhUybQlyg6uqPXg4JTK0801P+OfA==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -306,7 +306,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -664,7 +664,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "external-editor": {
@@ -2521,7 +2521,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -2662,7 +2662,7 @@
     },
     "sax": {
       "version": "1.2.1",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
@@ -2692,11 +2692,11 @@
       "dev": true
     },
     "sinon": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.1.0.tgz",
-      "integrity": "sha512-ffASxced8xr8eU0EGyfj9K++bRCtv/NyOFOxl7UBD86YH97oZjVxvecMhObwRlXe27GRUa6rVFEn67khPZ29rQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.1.1.tgz",
+      "integrity": "sha512-iYagtjLVt1vN3zZY7D8oH7dkjNJEjLjyuzy8daX5+3bbQl8gaohrheB9VfH1O3L6LKuue5WTJvFluHiuZ9y3nQ==",
       "requires": {
-        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/commons": "^1.2.0",
         "@sinonjs/formatio": "^3.0.0",
         "@sinonjs/samsam": "^2.1.2",
         "diff": "^3.5.0",
@@ -2782,7 +2782,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "text-table": {
@@ -2793,7 +2793,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -2931,7 +2931,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "versioncheckr",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "GitHub App to check if NPM versions get bumped during pull requests",
   "license": "MIT",
   "author": "Scott Williams",
@@ -13,10 +13,10 @@
   },
   "dependencies": {
     "@octokit/rest": "^15.15.1",
-    "aws-sdk": "^2.344.0",
+    "aws-sdk": "^2.346.0",
     "jsonwebtoken": "^8.3.0",
     "semver": "^5.6.0",
-    "sinon": "^7.1.0"
+    "sinon": "^7.1.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Fixing issue where check suites weren't being run on forks, and inadvertently being skipped with PR got opened from a form. No logging supporting ability to skip check.